### PR TITLE
Fix hostname and username filters

### DIFF
--- a/src/recordings.jsx
+++ b/src/recordings.jsx
@@ -719,7 +719,7 @@ class View extends React.Component {
      * Assumes journalctl is not running.
      */
     journalctlStart() {
-        let matches = ["_UID=" + this.uid, "+", "_EXE=/usr/bin/tlog-rec-session", "+", "_EXE=/usr/bin/tlog-rec", "+", "SYSLOG_IDENTIFIER=-tlog-rec-session"];
+        let matches = ["_EXE=/usr/bin/tlog-rec-session", "_EXE=/usr/bin/tlog-rec"];
         if (this.state.username && this.state.username !== "") {
             matches.push("TLOG_USER=" + this.state.username);
         }


### PR DESCRIPTION
Modify the default journalctl matches allowing correct behavior(logical AND)
of the appended _HOSTNAME and TLOG_USER filters.

This fixes the hostname and username input boxes filtering.