### PR TITLE
Makefile: Update bots target for moved GitHub project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,12 +133,14 @@ vm: $(VM_IMAGE)
 check: $(NODE_MODULES_TEST) $(VM_IMAGE) test/common
 	TEST_AUDIT_NO_SELINUX=1 test/check-application -s
 
-# checkout Cockpit's bots/ directory for standard test VM images and API to launch them
-# must be from cockpit's master, as only that has current and existing images; but testvm.py API is stable
+# checkout Cockpit's bots for standard test VM images and API to launch them
+# must be from master, as only that has current and existing images; but testvm.py API is stable
 bots:
-	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git
-	git checkout --force FETCH_HEAD -- bots/
-	git reset bots
+	if [ ! -d bots ]; then \
+		git clone --depth=1 https://github.com/cockpit-project/bots.git; \
+	else \
+		cd bots && git fetch && git reset --hard origin/master; \
+        fi
 
 # checkout Cockpit's test API; this has no API stability guarantee, so check out a stable tag
 # when you start a new project, use the latest relese, and update it from time to time
@@ -150,4 +152,4 @@ test/common:
 $(NODE_MODULES_TEST): package.json
 	npm install
 
-.PHONY: all clean install devel-install dist-gzip srpm rpm check vm update-po
+.PHONY: all bots clean install devel-install dist-gzip srpm rpm check vm update-po


### PR DESCRIPTION
Cockpit bots are in their own project now.

Make the target phony so that `make bots` updates an existing checkout.

Closes #228