### PR TITLE
Use --all journalctl option

### DIFF
--- a/src/pkg/lib/journal.js
+++ b/src/pkg/lib/journal.js
@@ -98,7 +98,7 @@
                 options.count = null;
         }
 
-        var cmd = [ "journalctl", "-q", "--output=json" ];
+        var cmd = [ "journalctl", "--all", "-q", "--output=json" ];
         if (!options.count)
             cmd.push("--no-tail");
         else


### PR DESCRIPTION
journalctl encodes fields with "non-printable" characters, like unicode control characters, as an array.

This ensures that the tlog MESSAGE field is shown in full using the journalctl API.