### PR TITLE
metainfo: Fix launchable and update description

### DIFF
--- a/org.cockpit-project.session-recording.metainfo.xml
+++ b/org.cockpit-project.session-recording.metainfo.xml
@@ -4,7 +4,7 @@
   <metadata_license>CC0-1.0</metadata_license>
   <name>Session Recording</name>
   <summary>
-    Provides Session Recording module for Cockpit.
+    Session Recording module for Cockpit
   </summary>
   <description>
     <p>
@@ -13,5 +13,5 @@
     </p>
   </description>
   <extends>org.cockpit_project.cockpit</extends>
-  <launchable type="cockpit-manifest">cockpit-session-recording</launchable>
+  <launchable type="cockpit-manifest">session-recording</launchable>
 </component>


### PR DESCRIPTION
`<launchable>` must coincide with the actual URL path defined by the
manifest.

Remove the period from <summary>, as the spec [1] suggests. Also remove
the redundant "Provides". This makes Cockpit's "Applications" page more
consistent.

[1] https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#sect-Metadata-GenericComponent

https://bugzilla.redhat.com/show_bug.cgi?id=1856639