### PR TITLE
Throttle journalctl restarts

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "raw-loader": "^0.5.1",
     "react": "16.13.1",
     "react-dom": "16.13.1",
+    "throttle-debounce": "2.3.0",
     "xterm": "^3.14.5"
   }
 }

--- a/src/recordings.jsx
+++ b/src/recordings.jsx
@@ -58,6 +58,7 @@ import {
     SearchIcon
 } from "@patternfly/react-icons";
 import { global_danger_color_200 } from "@patternfly/react-tokens";
+import { debounce } from 'throttle-debounce';
 
 const $ = require("jquery");
 const cockpit = require("cockpit");
@@ -741,6 +742,11 @@ export default class View extends React.Component {
         this.setState({ recordingList: [] });
     }
 
+    throttleJournalRestart = debounce(300, () => {
+        this.clearRecordings();
+        this.journalctlRestart();
+    });
+
     handleInputChange(name, value) {
         const state = {};
         state[name] = value;
@@ -793,8 +799,7 @@ export default class View extends React.Component {
             this.state.hostname !== prevState.hostname ||
             this.state.search !== prevState.search
         ) {
-            this.clearRecordings();
-            this.journalctlRestart();
+            this.throttleJournalRestart();
         }
     }
 


### PR DESCRIPTION
This addresses an issue with typeahead search generating a significant
load on the system, a single filter test run can make ~100 calls to
journalctl restart if not throttled.