### PR TITLE
test: Enter session-recording page

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -398,6 +398,7 @@ class TestApplication(MachineCase):
                 "".format(srrow)
         b, _ = self._login("/apps", srrow)
         b.click(srbut)
+        b.enter_page("/session-recording")
         b.wait_present("#app")
 
 if __name__ == "__main__":


### PR DESCRIPTION
Cockpit can have multiple pages opened at the same time. This is
handled through iframes. When switching between pages we need to tell
tests that we will be now working with different iframe.

Before this test was checking `b.wait_present("#app")` in `/apps` page
and not in `/session-recording` page.