### PR TITLE
Tests: Assert pause state with a later command in rec1

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -164,7 +164,7 @@ class TestApplication(MachineCase):
         b.click("#player-play-pause")
         time.sleep(10)
         # Make sure it didn't keep playing
-        b.wait_not_in_text(self._term_line(1), "whoami")
+        b.wait_not_in_text(self._term_line(6), "thisisatest123")
         # Test if it can start playing again
         b.click("#player-play-pause")
 


### PR DESCRIPTION
On some systems, the 'whoami' command may still show in the terminal output
if the pause does not happen fast enough.