### PR TITLE
Remove unneeded tlog UID code

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -25,7 +25,6 @@ blocks:
         commands:
           - export TEST_OS=fedora-35
           - bots/image-customize -v -i cockpit-ws -i cockpit-packagekit -i `pwd`/cockpit-session-recording*.noarch.rpm -s `pwd`/test/vm.install $TEST_OS
-          - bots/image-customize -v -r "usermod -u 981 tlog || true" $TEST_OS
           - bots/image-customize -v -u ./test/files/1.journal:/var/log/journal/1.journal $TEST_OS
           - bots/image-customize -v -u ./test/files/binary-rec.journal:/var/log/journal/binary-rec.journal $TEST_OS
           - test/check-application -v
@@ -33,7 +32,6 @@ blocks:
         commands:
           - export TEST_OS=centos-8-stream
           - bots/image-customize -v -i cockpit-ws -i cockpit-packagekit -i `pwd`/cockpit-session-recording*.noarch.rpm -s `pwd`/test/vm.install $TEST_OS
-          - bots/image-customize -v -r "usermod -u 981 tlog || true" $TEST_OS
           - bots/image-customize -v -u ./test/files/1.journal:/var/log/journal/1.journal $TEST_OS
           - bots/image-customize -v -u ./test/files/binary-rec.journal:/var/log/journal/binary-rec.journal $TEST_OS
           - test/check-application -v

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,6 @@ $(RPMFILE): $(TARFILE) cockpit-$(PACKAGE_NAME).spec
 $(VM_IMAGE): $(RPMFILE) bots
 	rm -f $(VM_IMAGE) $(VM_IMAGE).qcow2
 	bots/image-customize -v -i cockpit-ws -i cockpit-packagekit -i `pwd`/$(RPMFILE) -s $(CURDIR)/test/vm.install $(TEST_OS)
-	bots/image-customize -v -r "usermod -u 981 tlog || true" $(TEST_OS)
 	bots/image-customize -v -u ./test/files/1.journal:/var/log/journal/1.journal $(TEST_OS)
 	bots/image-customize -v -u ./test/files/binary-rec.journal:/var/log/journal/binary-rec.journal $(TEST_OS)
 

--- a/src/recordings.jsx
+++ b/src/recordings.jsx
@@ -561,8 +561,6 @@ export default class View extends React.Component {
         this.journalctlRecordingID = null;
         /* Recording ID -> data map */
         this.recordingMap = {};
-        /* tlog UID in system set in ComponentDidMount */
-        this.uid = null;
         const path = cockpit.location.path[0];
         this.state = {
             /* List of recordings in start order */
@@ -576,7 +574,7 @@ export default class View extends React.Component {
             hostname: cockpit.location.options.hostname || "",
             search: cockpit.location.options.search || "",
             /* filter values end */
-            error_tlog_uid: false,
+            error_tlog_user: false,
             diff_hosts: false,
             /* if config is open */
             config: path === "config",
@@ -794,13 +792,12 @@ export default class View extends React.Component {
         const proc = cockpit.spawn(["getent", "passwd", "tlog"]);
 
         proc.stream((data) => {
-            this.uid = data.split(":", 3)[2];
             this.journalctlStart();
             proc.close();
         });
 
         proc.fail(() => {
-            this.setState({ error_tlog_uid: true });
+            this.setState({ error_tlog_user: true });
         });
 
         cockpit.addEventListener("locationchanged",
@@ -838,7 +835,7 @@ export default class View extends React.Component {
     render() {
         if (this.state.config === true) {
             return <Config.Config />;
-        } else if (this.state.error_tlog_uid === true) {
+        } else if (this.state.error_tlog_user === true) {
             return (
                 <Bullseye>
                     <EmptyState variant={EmptyStateVariant.small}>
@@ -849,7 +846,7 @@ export default class View extends React.Component {
                             {_("Error")}
                         </Title>
                         <EmptyStateBody>
-                            {_("Unable to retrieve tlog UID from system.")}
+                            {_("Unable to retrieve tlog user from system.")}
                         </EmptyStateBody>
                     </EmptyState>
                 </Bullseye>

--- a/test/check-application
+++ b/test/check-application
@@ -15,7 +15,7 @@ sys.path.append(os.path.join(TEST_DIR, "common"))
 sys.path.append(os.path.join(os.path.dirname(TEST_DIR), "bots/machine"))
 from testlib import *
 
-# Test with pre-recorded journal with tlog UID 981
+# Test with pre-recorded journal files
 class TestApplication(MachineCase):
     def _login(self, loc="/session-recording", wait="#app"):
         self.login_and_go(loc)


### PR DESCRIPTION
The tlog UID was being set explicitly to ensure journalctl matches
used during tests would find pre-recorded journals. This is no longer
needed as we removed the TLOG_UID filter from the journalctl match
string.