### PR TITLE
Sync updates for the Python bridge

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -21,9 +21,9 @@ blocks:
           - make test/common
           - make bots
       jobs:
-      - name: Check fedora-35
+      - name: Check fedora-36
         commands:
-          - export TEST_OS=fedora-35
+          - export TEST_OS=fedora-36
           - bots/image-customize -v -i cockpit-ws -i cockpit-packagekit -i `pwd`/cockpit-session-recording*.noarch.rpm -s `pwd`/test/vm.install $TEST_OS
           - bots/image-customize -v -u ./test/files/1.journal:/var/log/journal/1.journal $TEST_OS
           - bots/image-customize -v -u ./test/files/binary-rec.journal:/var/log/journal/binary-rec.journal $TEST_OS

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,17 @@
 # extract name from package.json
 PACKAGE_NAME := $(shell awk '/"name":/ {gsub(/[",]/, "", $$2); print $$2}' package.json)
+RPM_NAME := cockpit-$(PACKAGE_NAME)
 VERSION := $(shell T=$$(git describe 2>/dev/null) || T=1; echo $$T | tr '-' '.')
 ifeq ($(TEST_OS),)
 TEST_OS = rhel-x
 endif
 export TEST_OS
 TARFILE=cockpit-$(PACKAGE_NAME)-$(VERSION).tar.xz
-RPMFILE=$(shell rpmspec -D"VERSION $(VERSION)" -q cockpit-session-recording.spec.in).rpm
+SPEC=$(RPM_NAME).spec
+# rpmspec -q behaves differently in Fedora ≥ 37
+RPMQUERY=$(shell rpmspec -D"VERSION $(VERSION)" -q --srpm $(SPEC).in).rpm
+SRPMFILE=$(subst noarch,src,$(RPMQUERY))
+RPMFILE=$(subst src,noarch,$(RPMQUERY))
 VM_IMAGE=$(CURDIR)/test/images/$(TEST_OS)
 # stamp file to check if/when npm install ran
 NODE_MODULES_TEST=package-lock.json

--- a/src/index.html
+++ b/src/index.html
@@ -20,7 +20,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 <html>
 
 <head>
-    <title translateable="yes">Session Recording</title>
+    <title translate>Session Recording</title>
     <meta charset="utf-8">
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/src/index.html
+++ b/src/index.html
@@ -28,7 +28,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="index.css">
     
     <script type="text/javascript" src="../base1/cockpit.js"></script>
-    <script type="text/javascript" src="../*/po.js"></script>
+    <script type="text/javascript" src="po.js"></script>
     <script type="text/javascript" src="index.js"></script>
 </head>
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -91,17 +91,11 @@ const plugins = [
 
 /* Only minimize when in production mode */
 if (production) {
-    /* Rename output files when minimizing */
-    output.filename = "[name].min.js";
-
     plugins.unshift(
         new CompressionPlugin({
-            asset: "[path].gz[query]",
-            test: /\.(js|html)$/,
-            minRatio: 0.9,
+            test: /\.(css|js|html)$/,
             deleteOriginalAssets: true,
-        })
-    );
+    }));
 }
 
 var babel_loader = {


### PR DESCRIPTION
This updates session-recording to be compatible with the Python bridge which is a re-implementation of the C bridge into Python. This no longer loads JavaScript from .min.js files and does not support the translation globbing.

I've also made an attempt to get the tests running again, it seems to run locally but not everything passes.