### PR TITLE
package.json: drop flowtype plugin

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,7 +9,7 @@
         "ecmaVersion": "2022",
         "sourceType": "module"
     },
-    "plugins": ["flowtype", "react", "react-hooks"],
+    "plugins": ["react", "react-hooks"],
     "rules": {
         "indent": ["error", 4,
             {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "eslint-config-standard": "^17.0.0-1",
     "eslint-config-standard-jsx": "^11.0.0-1",
     "eslint-config-standard-react": "^13.0.0",
-    "eslint-plugin-flowtype": "^8.0.3",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.0.0",


### PR DESCRIPTION
None of the JavaScript code uses flowtype type annotations.