### PR TITLE
dependabot: Don't update major React version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,10 @@ updates:
       - dependency-name: "@patternfly/*"
         update-types: ["version-update:semver-major"]
 
+      # PF5 requires React 18
+      - dependency-name: "*react*"
+        update-types: ["version-update:semver-major"]
+
   - package-ecosystem: "github-actions"
     directory: "/"
     open-pull-requests-limit: 3


### PR DESCRIPTION
PatternFly 5 has a React 18 peer dependency, so they need to be updated together.

(cherry picked from commit a9f076c681463e31fa81ee662574a095447016fe)